### PR TITLE
Make pacman-offline-prepare depend on network

### DIFF
--- a/systemd/pacman-offline-done-poweroff.service
+++ b/systemd/pacman-offline-done-poweroff.service
@@ -8,6 +8,7 @@
 
 [Unit]
 Description=Offline system update with pacman - Poweroff
+Documentation=https://git.eworm.de/cgit/pacman-offline/about/
 After=pacman-offline.service
 DefaultDependencies=no
 Conflicts=shutdown.target

--- a/systemd/pacman-offline-done-reboot.service
+++ b/systemd/pacman-offline-done-reboot.service
@@ -8,6 +8,7 @@
 
 [Unit]
 Description=Offline system update with pacman - Reboot
+Documentation=https://git.eworm.de/cgit/pacman-offline/about/
 After=pacman-offline.service
 DefaultDependencies=no
 Conflicts=shutdown.target

--- a/systemd/pacman-offline-prepare.service
+++ b/systemd/pacman-offline-prepare.service
@@ -7,6 +7,7 @@
 
 [Unit]
 Description=Prepare pacman offline system-update
+Documentation=https://git.eworm.de/cgit/pacman-offline/about/
 ConditionPathExists=!/var/lib/pacman/db.lck
 
 [Service]

--- a/systemd/pacman-offline-prepare.service
+++ b/systemd/pacman-offline-prepare.service
@@ -9,6 +9,9 @@
 Description=Prepare pacman offline system-update
 Documentation=https://git.eworm.de/cgit/pacman-offline/about/
 ConditionPathExists=!/var/lib/pacman/db.lck
+# Synchronizing databases needs network, see https://systemd.io/NETWORK_ONLINE/
+After=network-online.target
+Wants=network-online.target
 
 [Service]
 Type=oneshot

--- a/systemd/pacman-offline-prepare.timer
+++ b/systemd/pacman-offline-prepare.timer
@@ -7,6 +7,7 @@
 
 [Unit]
 Description=Prepare pacman offline system-update
+Documentation=https://git.eworm.de/cgit/pacman-offline/about/
 
 [Timer]
 OnBootSec=5min

--- a/systemd/pacman-offline-reboot.timer
+++ b/systemd/pacman-offline-reboot.timer
@@ -7,6 +7,7 @@
 
 [Unit]
 Description=Reboot for pacman offline system-update
+Documentation=https://git.eworm.de/cgit/pacman-offline/about/
 
 [Timer]
 OnCalendar=03:00:00

--- a/systemd/pacman-offline.service
+++ b/systemd/pacman-offline.service
@@ -7,6 +7,7 @@
 
 [Unit]
 Description=Offline system update with pacman
+Documentation=https://git.eworm.de/cgit/pacman-offline/about/
 ConditionPathIsSymbolicLink=/system-update
 DefaultDependencies=false
 Requires=sysinit.target dbus.socket


### PR DESCRIPTION
systemd-offline-prepare.service attempts to sync the databases which naturally needs network.

I also added `Documentation` to all units; this makes a link to this repository appear in the output of `systemctl status` which I personally find quite helpful.